### PR TITLE
Make exercise 8 Unicode aware

### DIFF
--- a/exercises/08_finale/exercise/src/main.rs
+++ b/exercises/08_finale/exercise/src/main.rs
@@ -63,12 +63,13 @@ mod test {
         }
 
         {
-            let candidate1 = "abcde".to_string();
+            // Change '😈' to 'e' if you don't want to deal with unicode.
+            let candidate1 = "abcd😈".to_string();
             let result = matcher.match_string(&candidate1);
             assert_eq!(result, vec![
                 (&MatcherToken::RawText("abc"), "abc"),
                 (&MatcherToken::OneOfText(vec!["d", "e", "f"]), "d"),
-                (&MatcherToken::WildCard, "e")
+                (&MatcherToken::WildCard, "😈")
             ]);
             assert_eq!(matcher.most_tokens_matched, 3);
         }

--- a/exercises/08_finale/solutions/src/main.rs
+++ b/exercises/08_finale/solutions/src/main.rs
@@ -72,8 +72,12 @@ impl<'a> Matcher<'a> {
             }
             match token {
                 MatcherToken::WildCard => {
-                    answer.push((token, &string_left[..1]));
-                    string_left = &string_left[1..];
+                    let byte_offset = string_left
+                        .char_indices()
+                        .nth(1)
+                        .map_or_else(|| string_left.len(), |(off, _)| off);
+                    answer.push((token, &string_left[..byte_offset]));
+                    string_left = &string_left[byte_offset..];
                 }
                 MatcherToken::OneOfText(options) => {
                     for start in options {
@@ -129,12 +133,13 @@ mod test {
         }
 
         {
-            let candidate1 = "abcde".to_string();
+            // Change '😈' to 'e' if you don't want to deal with unicode.
+            let candidate1 = "abcd😈".to_string();
             let result = matcher.match_string(&candidate1);
             assert_eq!(result, vec![
                 (&MatcherToken::RawText("abc"), "abc"),
                 (&MatcherToken::OneOfText(vec!["d", "e", "f"]), "d"),
-                (&MatcherToken::WildCard, "e")
+                (&MatcherToken::WildCard, "😈")
             ]);
             assert_eq!(matcher.most_tokens_matched, 3);
         }


### PR DESCRIPTION
Changes exercise 8 test data to contain a Unicode character in a place where it's easy to accidentally not think about byte boundaries.  Adds a tiny comment to suggest using the original test data in case the user doesn't want to deal with Unicode while writing the solution.

I don't know if you want to distract from the problem at hand by introducing an extra hurdle to jump through. I also don't know that my solution is even the Rust idiomatic one. I was surprised to not see a method that provided the byte offset directly.