### PR TITLE
Adds some opt-in Unicode comments and sample solution to chapter 08

### DIFF
--- a/exercises/08_finale/README.md
+++ b/exercises/08_finale/README.md
@@ -56,3 +56,12 @@ we've matched is 3. We'd return a vec containing:
  - (`OneOfText(["Black", "Bridge"])`, `Bridge`)
  - (`OneOfText(["rock", "stone", "water"])`, `"stone"`)
  - (`Wildcard`, `"_"`)
+
+### A Note On Unicode
+
+Rust is able to deal with unicode characters (like emoji or Japanese Kanji) in its strings.
+Of course, this increases the amount of complexity that is required for simple operations like
+splitting a string into pieces, because it's possible to accidentally split a character in half.
+
+The tests in the example *do not* use unicode, however if you want a "true" Rust experience,
+change the tests to include a unicode character (an example is in the comments).

--- a/exercises/08_finale/exercise/src/main.rs
+++ b/exercises/08_finale/exercise/src/main.rs
@@ -63,12 +63,13 @@ mod test {
         }
 
         {
+            // Change 'e' to '💪' if you want to test unicode.
             let candidate1 = "abcde".to_string();
             let result = matcher.match_string(&candidate1);
             assert_eq!(result, vec![
                 (&MatcherToken::RawText("abc"), "abc"),
                 (&MatcherToken::OneOfText(vec!["d", "e", "f"]), "d"),
-                (&MatcherToken::WildCard, "e")
+                (&MatcherToken::WildCard, "e") // or '💪'
             ]);
             assert_eq!(matcher.most_tokens_matched, 3);
         }


### PR DESCRIPTION
This commit adds a couple of comments to the exercise that shows our test string is not using Unicode in a tricky place.  The solution, however, does support Unicode, even though our test doesn't require it.  A comment explains what's going on.

FWIW, I spent a little time reading about utf-8 and the `char` type and I believe that using `len_utf8` is the best way to get the byte offset.

Nevertheless, I won't mind if you choose to leave this out entirely. I do see how it can be a distraction. My only concern is that someone new to Rust might think the solution with the hardcoded 1 (and hence limited to ASCII) is the "right way" to do it, since it's showing up in a learning exercise. OTOH, I may simply be overthinking it.