### PR TITLE
fix(02_lifetimes_explained): Remove out of place text

### DIFF
--- a/exercises/02_lifetimes_explained/exercise/src/lib.rs
+++ b/exercises/02_lifetimes_explained/exercise/src/lib.rs
@@ -15,9 +15,6 @@ pub fn identity(number: &i32) -> &i32 {
     number
 }
 
-/// In this case, we know that if the option is `Some`, it will
-/// always contain a reference to `number`.
-///
 /// Recall that this function returns a vector of slices of
 /// `text`, split by `delimiter`.
 ///

--- a/exercises/02_lifetimes_explained/solutions/src/lib.rs
+++ b/exercises/02_lifetimes_explained/solutions/src/lib.rs
@@ -53,9 +53,6 @@ pub fn only_if_greater<'a, 'b>(number: &'a i32, greater_than: &'b i32) -> Option
     }
 }
 
-/// In this case, we know that if the option is `Some`, it will
-/// always contain a reference to `number`.
-///
 /// Recall that this function returns a vector of slices of
 /// `text`, split by `delimiter`.
 ///


### PR DESCRIPTION
There is some out of place text in both the exercise and solution for `02_lifetimes_explained`. This text seems to be the same as can be found [here](https://github.com/tfpk/lifetimekata/blob/1ad5235dd44ad235f762645d006aaf8f906f5f1c/exercises/02_lifetimes_explained/solutions/src/lib.rs#L21).

As it is currently confusing for the reader as to what this text is talking about I think it might be best to remove it (especially since it is duplicate text from a different exercise/solution).